### PR TITLE
Css refactor links

### DIFF
--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -8,9 +8,6 @@ import SIZE from "../../constants/Size";
 
 const MenuItemStyledLink = styled(Link)`
   text-decoration: none;
-  /* color: #1f4070; */
-  /* color: inherit; */
-
   color: ${COLORS.DARK_BLUE};
 `;
 

--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -8,6 +8,8 @@ import SIZE from "../../constants/Size";
 
 const MenuItemStyledLink = styled(Link)`
   text-decoration: none;
+  /* color: #1f4070; */
+  color: inherit;
 `;
 
 const MenuItemInfoWrapper = styled.div`

--- a/src/components/MenuItem/index.tsx
+++ b/src/components/MenuItem/index.tsx
@@ -9,7 +9,9 @@ import SIZE from "../../constants/Size";
 const MenuItemStyledLink = styled(Link)`
   text-decoration: none;
   /* color: #1f4070; */
-  color: inherit;
+  /* color: inherit; */
+
+  color: ${COLORS.DARK_BLUE};
 `;
 
 const MenuItemInfoWrapper = styled.div`


### PR DESCRIPTION
### Issue #19 

## Changes: 
Removed default link color and default text decoration from the menu Item links. It now looks like this:

![Screenshot 2022-04-18 11 57 37 AM](https://user-images.githubusercontent.com/40967002/163799757-c26a761a-1128-4456-9221-ac9a06577275.png)

