### PR TITLE
feat: added text changes to the content script

### DIFF
--- a/public/scripts/content.js
+++ b/public/scripts/content.js
@@ -1,4 +1,5 @@
 const FLOATING_DIV_ID = 'floating-overlay';
+const TEXT_STYLE_ID = 'text-style-id';
 
 function renderFloatingOverlay({ color }) {
   const floatingDiv = document.createElement('div');
@@ -39,6 +40,30 @@ function removeFloatingOverlay() {
   overlay.remove();
 }
 
+function addTextStyles(textSettings) {
+  if (!textSettings.enabled) {
+    return;
+  }
+
+  const css = `
+    * {
+      color: ${textSettings.textColor} !important;
+    }
+  `;
+  const head = document.head || document.getElementsByTagName('head')[0];
+  const styleEl = document.createElement('style');
+  styleEl.id = TEXT_STYLE_ID;
+  head.appendChild(styleEl);
+  styleEl.appendChild(document.createTextNode(css));
+}
+
+function removeTextStyles() {
+  const styleEl = document.getElementById(TEXT_STYLE_ID);
+  if (styleEl) {
+    styleEl.remove();
+  }
+}
+
 function handleOnStorageChange(changes, areaName) {
   const newState = changes.appState.newValue;
   const oldState = changes.appState.oldValue;
@@ -54,6 +79,15 @@ function handleOnStorageChange(changes, areaName) {
       overlay.style.background = newState.overlay.color;
     }
   }
+
+  if (
+    newState.text.enabled !== oldState.text.enabled ||
+    newState.text.fontFamily !== oldState.text.fontFamily ||
+    newState.text.textColor !== oldState.text.textColor
+  ) {
+    removeTextStyles();
+    addTextStyles(newState.text);
+  }
 }
 
 (async function () {
@@ -66,5 +100,9 @@ function handleOnStorageChange(changes, areaName) {
 
   if (appState.overlay.enabled) {
     renderFloatingOverlay(appState.overlay);
+  }
+
+  if (appState.text.enabled) {
+    addTextStyles(appState.text);
   }
 })()

--- a/src/pages/OverlayTint/index.test.tsx
+++ b/src/pages/OverlayTint/index.test.tsx
@@ -17,7 +17,9 @@ describe("testing OverLayTint component", () => {
   it("should update app state when the toggle is clicked", () => {
     const appData = {
       enabled: false,
-      text: {},
+      text: {
+        enabled: false
+      },
       overlay: {
         enabled: false,
         color: COLORS.LIGHT_YELLOW
@@ -44,7 +46,9 @@ describe("testing OverLayTint component", () => {
   it("should update app state when color is selected", () => {
     const appData = {
       enabled: false,
-      text: {},
+      text: {
+        enabled: false
+      },
       overlay: {
         enabled: false,
         color: COLORS.LIGHT_YELLOW

--- a/src/pages/TextSettings/index.test.tsx
+++ b/src/pages/TextSettings/index.test.tsx
@@ -1,8 +1,10 @@
 import { expect } from "@jest/globals";
-import { screen, render } from "@testing-library/react";
+import { screen, render, fireEvent } from "@testing-library/react";
 
 import TestWrapper from "../../test-utils/TestWrapper";
 import TextSettings from ".";
+import COLORS from "../../constants/colors";
+import StoreContext from "../../storage/StoreContext";
 
 describe("testing TextSettings component", () => {
   it("should render <TextSettings/>", () => {
@@ -13,5 +15,63 @@ describe("testing TextSettings component", () => {
     );
     let textSettingsContainer = screen.getByTestId("textSettingsContainer");
     expect(textSettingsContainer).toBeTruthy();
+  });
+
+  it("should update text color in state", () => {
+    const appData = {
+      enabled: false,
+      text: {
+        enabled: false
+      },
+      overlay: {
+        enabled: false,
+        color: COLORS.LIGHT_YELLOW
+      }
+    };
+    const setAppState = jest.fn();
+    render(
+      <StoreContext.Provider value={{appData, setAppState}} >
+        <TextSettings />
+      </StoreContext.Provider>
+    );
+
+    fireEvent.click(screen.getByTestId(COLORS.GRAY));
+
+    expect(setAppState).toHaveBeenCalledWith({
+      ...appData,
+      text: {
+        ...appData.text,
+        textColor: COLORS.GRAY
+      }
+    });
+  });
+
+  it("should update text settings enable in the memory", () => {
+    const appData = {
+      enabled: false,
+      text: {
+        enabled: false
+      },
+      overlay: {
+        enabled: false,
+        color: COLORS.LIGHT_YELLOW
+      }
+    };
+    const setAppState = jest.fn();
+    render(
+      <StoreContext.Provider value={{appData, setAppState}} >
+        <TextSettings />
+      </StoreContext.Provider>
+    );
+
+    fireEvent.click(screen.getByTestId('toggle'));
+
+    expect(setAppState).toHaveBeenCalledWith({
+      ...appData,
+      text: {
+        ...appData.text,
+        enabled: true
+      }
+    });
   });
 });

--- a/src/pages/TextSettings/index.tsx
+++ b/src/pages/TextSettings/index.tsx
@@ -6,6 +6,8 @@ import COLORS from "../../constants/colors";
 import SIZE from "../../constants/size";
 import ColorPicker from "../../components/ColorPicker";
 import Toggle from "../../components/Toggle";
+import { useContext } from "react";
+import StoreContext from "../../storage/StoreContext";
 
 const StyledTextSettingsContainer = styled.div`
   display: flex;
@@ -19,13 +21,35 @@ const StyledTextSettingsContainer = styled.div`
 `;
 
 export default function TextSettings() {
+  const { appData, setAppState } = useContext(StoreContext);
+
+  function handleOnEnableChange(val: boolean) {
+    setAppState({
+      ...appData,
+      text: {
+        ...appData.text,
+        enabled: val
+      }
+    })
+  }
+
+  function handleOnColorChange(color: string) {
+    setAppState({
+      ...appData,
+      text: {
+        ...appData.text,
+        textColor: color
+      }
+    })
+  }
+
   return (
     <StyledTextSettingsContainer data-testid="textSettingsContainer">
-      <Toggle on={true} />
+      <Toggle on={appData.text.enabled} onStateChange={handleOnEnableChange} />
       <p>The quick brown fox jumps over the lazy dog</p>
       <DropDownFontText />
       <ChangeSize />
-      <ColorPicker onChange={() => {}} />
+      <ColorPicker color={appData.text.textColor} onChange={handleOnColorChange} />
     </StyledTextSettingsContainer>
   );
 }

--- a/src/storage/StoreContext/index.test.tsx
+++ b/src/storage/StoreContext/index.test.tsx
@@ -9,6 +9,7 @@ describe('src/storage/StoreContext.ts', () => {
     const mockValue = {
       enabled: false,
       text: {
+        enabled: false
       },
       overlay: {
         enabled: false,

--- a/src/storage/StoreContext/index.ts
+++ b/src/storage/StoreContext/index.ts
@@ -4,6 +4,7 @@ import COLORS from "../../constants/colors";
 export type AppData = {
   enabled: boolean,
   text: {
+    enabled: boolean,
     fontFamily?: string,
     textColor?: string
   },
@@ -21,6 +22,7 @@ type AppState = {
 const initialState: AppData = {
   enabled: false,
   text: {
+    enabled: false
   },
   overlay: {
     enabled: false,

--- a/src/storage/chrome-storage/index.test.ts
+++ b/src/storage/chrome-storage/index.test.ts
@@ -14,7 +14,9 @@ describe('src/storage/chrome-storage/index.ts', () => {
   it('should set the store value in the chrome app', () => {
     const appState = {
       enabled: false,
-      text: {},
+      text: {
+        enabled: false
+      },
       overlay: {
         enabled: false,
         color: COLORS.LIGHT_YELLOW
@@ -31,7 +33,9 @@ describe('src/storage/chrome-storage/index.ts', () => {
   it('should be able to fetch data from local storage when data exists', async () => {
     const appState = {
       enabled: false,
-      text: {},
+      text: {
+        enabled: false
+      },
       overlay: {
         enabled: false,
         color: COLORS.LIGHT_YELLOW
@@ -49,7 +53,9 @@ describe('src/storage/chrome-storage/index.ts', () => {
   it('should be able to return initial data when data does not exists in storage', async () => {
     const appState = {
       enabled: false,
-      text: {},
+      text: {
+        enabled: false
+      },
       overlay: {
         enabled: false,
         color: COLORS.LIGHT_YELLOW

--- a/src/storage/chrome-storage/index.ts
+++ b/src/storage/chrome-storage/index.ts
@@ -4,6 +4,7 @@ import { AppData } from "../StoreContext";
 const initialState = {
   enabled: false,
   text: {
+    enabled: false
   },
   overlay: {
     enabled: false,


### PR DESCRIPTION
## Issue
#3 

## Changes
- Save text settings "enabled" and "text-color" to memory
- Added tests
- Read the settings in contents scripts and apply the settings

![image](https://user-images.githubusercontent.com/7867644/169398922-1ab4b8b9-7d0b-4ad8-bf2f-6a35828e8f37.png)
![image](https://user-images.githubusercontent.com/7867644/169398963-e44bfe8b-50e0-4cfb-b75f-856fe7f7dbf4.png)
![image](https://user-images.githubusercontent.com/7867644/169398997-b98e7705-b214-4d0a-9ece-48e9bbf9215b.png)
 