### PR TITLE
fix: fixed the state reconciliation with older state where attributes are missing

### DIFF
--- a/popup/storage/chrome-storage/index.ts
+++ b/popup/storage/chrome-storage/index.ts
@@ -31,12 +31,35 @@ export function saveAppState(appState: AppData) {
   return chrome.storage.sync.set({ appState });
 }
 
+async function setInitialState(): Promise<AppData> {
+  await chrome.storage.sync.set({ appState: initialState });
+  return initialState;
+}
+
+async function verifyAndReconciliationOfState(appState: AppData): Promise<AppData> {
+  let shouldUpdateChromeStore = false;
+  for (let key in initialState) {
+    if (!appState[key]) {
+      appState[key] = initialState[key];
+      shouldUpdateChromeStore = true;
+    } else {
+      appState[key] = appState[key];
+    }
+  }
+
+  if (shouldUpdateChromeStore) {
+    await saveAppState(appState);
+  }
+
+  return appState;
+}
+
 export async function fetchAppStateFromStorage(): Promise<AppData> {
   return new Promise(async (resolve) => {
     const data = await chrome.storage.sync.get('appState');
     if (data && data.appState) {
-      resolve(data.appState as AppData)
-      return;
+      const reconciledState = await verifyAndReconciliationOfState(data.appState);
+      resolve(reconciledState)
     }
     else {
       await chrome.storage.sync.set({ appState: initialState });


### PR DESCRIPTION
# Changes
- Handled the scenario when the new state object is added and the clients have old schema with the settings missing
- The fix will add any new config to the existing state on first popup load