### PR TITLE
launches feedback page when user uninstall the chrome extension

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -1,0 +1,5 @@
+export { }
+
+chrome.runtime.setUninstallURL(
+    "https://forms.gle/kVPYg1XVeNPr2E9r5"
+)


### PR DESCRIPTION
#139 

## Changes

- Added feedback form link in background script which launches form once the user removes Dyslens from the browser.

![Screenshot 2023-03-28 16 22 19](https://user-images.githubusercontent.com/40967002/228287725-d8614d49-1899-4cde-8acb-e1078890f44d.png)


![Screenshot 2023-03-28 16 22 44](https://user-images.githubusercontent.com/40967002/228287743-139d05ae-6783-4ffc-ae24-2d5ddb037a0e.png)

![Screenshot 2023-03-28 16 23 12](https://user-images.githubusercontent.com/40967002/228288501-c62514aa-c4fa-4d58-ba5b-a098798e55dc.png)


